### PR TITLE
Add an optional flag --prefixes-file to list command

### DIFF
--- a/load.go
+++ b/load.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	miniogo "github.com/minio/minio-go/v7"
 )
@@ -112,7 +111,7 @@ func (m *migrateState) init(ctx context.Context) {
 		m.addWorker(ctx)
 	}
 	go func() {
-		f, err := os.OpenFile(path.Join(dirPath, failMigFile+time.Now().Format(".01-02-2006-15-04-05")), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		f, err := os.OpenFile(path.Join(dirPath, getFileName(failMigFile, "")), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 		if err != nil {
 			logDMsg("could not create + migration_fails.txt", err)
 			return
@@ -138,7 +137,7 @@ func (m *migrateState) init(ctx context.Context) {
 		}
 	}()
 	go func() {
-		f, err := os.OpenFile(path.Join(dirPath, logMigFile+time.Now().Format(".01-02-2006-15-04-05")), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		f, err := os.OpenFile(path.Join(dirPath, getFileName(logMigFile, "")), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 		if err != nil {
 			logDMsg("could not create + migration_log.txt", err)
 			return

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = os.Args[0]
 	app.Author = "MinIO, Inc."
+	app.Version = "0.0.5"
 	app.Description = `Migration tool from HCP ObjectStore to MinIO`
 	app.Flags = []cli.Flag{}
 	app.Action = mainAction


### PR DESCRIPTION
to list content of only the child prefixes under the namespace URL.

Output of each listing under a prefix is written to
a separate file.